### PR TITLE
Allow RGBA HEX values as colors

### DIFF
--- a/source/utils.ts
+++ b/source/utils.ts
@@ -9,8 +9,8 @@ export const normalizeColor = (style: string) => {
 		let color = style;
 		if (color.length < 6) {
 			color = [...color.slice(0, 3)].map(x => x.repeat(2)).join('');
-		} else if (color.length > 6) {
-			color = color.slice(0, 6);
+		} else if (color.length > 8) {
+			color = color.slice(0, 8);
 		}
 
 		return '#' + color;

--- a/vercel.json
+++ b/vercel.json
@@ -10,5 +10,6 @@
   },
   "github": {
     "silent": true
-  }
+  },
+  "outputDirectory": "distribution"
 }


### PR DESCRIPTION
Added [`outputDirectory`](https://vercel.com/docs/project-configuration#project-configuration/output-directory) to *vercel.json* to allow a complete automated deployment just running `vercel dev`, seems that the default directory is `./public/`.

Resolves #2 