### PR TITLE
Add `inherit` as color option, and explicit `brand` on darkModeColor

### DIFF
--- a/source/colors.js
+++ b/source/colors.js
@@ -60,6 +60,7 @@ export const cssKeywords = {
 	hotpink: '#ff69b4',
 	indianred: '#cd5c5c',
 	indigo: '#4b0082',
+	inherit: 'currentColor',
 	ivory: '#fffff0',
 	khaki: '#f0e68c',
 	lavenderblush: '#fff0f5',

--- a/source/icon.js
+++ b/source/icon.js
@@ -24,9 +24,9 @@ export const getSimpleIcon = (slug) => {
 
 export const getIconSvg = (icon, color = '', darkModeColor = '') => {
 	const hex = normalizeColor(color) || `#${icon.hex}`;
-	const darkModeHex = normalizeColor(darkModeColor);
+	const darkModeHex = darkModeColor === 'brand' ? `#${icon.hex}` : normalizeColor(darkModeColor);
 
-	if (darkModeColor && hex !== darkModeHex) {
+	if (hex !== darkModeHex) {
 		return icon.svg.replace(
 			'<path ',
 			`<style>path{fill:${hex}} @media (prefers-color-scheme:dark){path{fill:${darkModeHex}}}</style><path `,

--- a/source/icon.js
+++ b/source/icon.js
@@ -26,7 +26,7 @@ export const getIconSvg = (icon, color = '', darkModeColor = '') => {
 	const hex = normalizeColor(color) || `#${icon.hex}`;
 	const darkModeHex = darkModeColor === 'brand' ? `#${icon.hex}` : normalizeColor(darkModeColor);
 
-	if (hex !== darkModeHex) {
+	if ((hex !== darkModeHex) && darkModeColor !== '') {
 		return icon.svg.replace(
 			'<path ',
 			`<style>path{fill:${hex}} @media (prefers-color-scheme:dark){path{fill:${darkModeHex}}}</style><path `,

--- a/source/icon.js
+++ b/source/icon.js
@@ -26,7 +26,7 @@ export const getIconSvg = (icon, color = '', darkModeColor = '') => {
 	const hex = normalizeColor(color) || `#${icon.hex}`;
 	const darkModeHex = darkModeColor === 'brand' ? `#${icon.hex}` : normalizeColor(darkModeColor);
 
-	if ((hex !== darkModeHex) && darkModeColor !== '') {
+	if ((hex !== darkModeHex) && (darkModeColor !== '')) {
 		return icon.svg.replace(
 			'<path ',
 			`<style>path{fill:${hex}} @media (prefers-color-scheme:dark){path{fill:${darkModeHex}}}</style><path `,


### PR DESCRIPTION
**Issue:** closes #8 

Allows a user to specify 'inherit' in either color field to display SVG in same color as surroundings (if embedding SVG directly)
Allows a user to explictly mention 'brand' in the second field, if a different color is used in the first field.

Demos:
[<img src="https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe" width=24 height=24>](https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe) displays in the brand color - regardless of light/dark mode

[<img src="https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe/black/white" width=24 height=24>](https://simple-icons-mdo0y7i8c-litomore.vercel.app/inherit) displays in color to match surrounding elements - regardles of lgiht/dark mode

[<img src="https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe/black/brand" width=24 height=24>](https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe/inherit/brand) inherits surrounding color by default, uses brand color in dark mode.

[<img src="https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe/_/white" width=24 height=24>](https://simple-icons-mdo0y7i8c-litomore.vercel.app/adobe/_/inherit) displays brand color in light mode - but 'inherits' in dark mode.