### PR TITLE
Fix `viewBox` attribute for auto-viewbox icons

### DIFF
--- a/source/icon.ts
+++ b/source/icon.ts
@@ -84,7 +84,7 @@ export const getIconSvg = (icon: SimpleIcon, options: {
 
 			iconSvg = iconSvg
 				.replace(
-					`viewBox="0 0 ${baseIconSize} ${baseIconSize}`,
+					`viewBox="0 0 ${baseIconSize} ${baseIconSize}"`,
 					`viewBox="0 0 ${betterViewboxWidth} ${baseIconSize}"`,
 				)
 				.replace(/<path d=".*"\/>/, `<path d="${path}"/>`);


### PR DESCRIPTION
This PR fix when viewbox set to `auto`, return not valid XML.

see https://cdn.simpleicons.org/1dot1dot1dot1?viewbox=auto

i also want to add test for this, but it need more third-party dependency, just abandon.